### PR TITLE
Implement mixture model compatibility

### DIFF
--- a/slamdunk/dunks/tcounter.py
+++ b/slamdunk/dunks/tcounter.py
@@ -283,7 +283,7 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
 
             for (tc, nt), count in cB.items():
                 
-                row = [utr.chromosome, utr.name, utr.start, utr.end, utr.strand]
+                row = [utr.chromosome, utr.name, utr.start, utr.stop, utr.strand]
                 row.extend([tc, nt, count])
                 wr.writerow(row)
 

--- a/slamdunk/dunks/tcounter.py
+++ b/slamdunk/dunks/tcounter.py
@@ -153,7 +153,7 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
 
     ### NEW CODE
     ## Create cB output file if necessary
-    if (makecB):
+    if (makeCB):
 
         header = ['chromosome', 'UTR_name', 'UTR_start', 'UTR_end', 'UTR_strand', 'TC', 'nT', 'n']
         fileCB = open(outputCB, 'w')
@@ -219,7 +219,7 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
         ### NEW CODE
         ## Dictionary to track number of unique combos
         ## of T-to-C counts and T counts
-        if (makecB):
+        if (makeCB):
 
             cB = {}
 
@@ -259,7 +259,7 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
                         testk += 1
 
             ### NEW CODE
-            if (makecB):
+            if (makeCB):
 
                 key = (testk, testN)
 
@@ -279,9 +279,9 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
                     coverageUtr[i] += 1
 
         ### NEW CODE
-        if (makecB):
+        if (makeCB):
 
-            for (tc, nt), count in cU.items():
+            for (tc, nt), count in cB.items():
                 
                 row = [utr.chromosome, utr.name, utr.start, utr.end, utr.strand]
                 row.extend([tc, nt, count])
@@ -366,7 +366,7 @@ def computeTconversions(ref, bed, snpsFile, bam, maxReadLength, minQual, outputC
     fileBedgraphMinus.close()
 
     ### NEW CODE
-    if (makecB):
+    if (makeCB):
 
         fileCB.close()
 


### PR DESCRIPTION
I still need to run some tests and update the documentation accordingly, but this is my idea for how to address #153. After diving into the code base more, it seemed like the proposed change would make more sense as an optional addition to the count dunk. Currently I have it set to the non-default option, but I don't think it wouldn't be a bad idea to create this output by default; it should only incur a minimal additional RAM and runtime penalty, though there are some less trivial disk space requirements (depends on bam file size, probably in the 100 MB - 1GB range for your average bam file).

Let me know if you oppose this implementation strategy, or if anything stands out as obviously buggy with this implementation. If you are ok with the changes, I will work to run some tests, edit the documentation, and update the pull request.